### PR TITLE
feature: GTMタグとフォーム送信後の回答ありがとうページ閲覧時にカスタムイベントを送信する機能を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,29 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>flattail-lp</title>
+
+    <!-- Google Tag Manager (head) -->
+    <script>
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-WSF5XT45');
+    </script>
+    <!-- END GTM -->
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript>
+      <iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-WSF5XT45"
+        height="0"
+        width="0"
+        style="display:none;visibility:hidden"
+      ></iframe>
+    </noscript>
+    <!-- END GTM -->
+
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/components/form/FormSuccess.tsx
+++ b/src/components/form/FormSuccess.tsx
@@ -1,6 +1,23 @@
+import { useEffect } from "react";
 import { Button } from "../ui/button";
 
+// TypeScriptにdataLayerの存在を教える
+declare global {
+  interface Window {
+    dataLayer: Record<string, any>[];
+  }
+}
+
 const FormSuccess = () => {
+  useEffect(() => {
+    // GTM用イベント送信
+    if (window.dataLayer) {
+      window.dataLayer.push({
+        event: "form_success", // ← GTMのトリガー名と一致させる
+      });
+    }
+  }, []);
+
   return (
     <div
       className={`min-h-[calc(100dvh-var(--header-height-mobile)-5rem)] sm:min-h-[calc(100dvh-var(--header-height-pc)-10rem)]`}


### PR DESCRIPTION
### 関連issue番号
#1

### 修正内容
- Google Tag Manager（GTM）タグを `index.html` に追加し、全ページでGTMが読み込まれるように設定
- フォーム送信完了後に表示される `FormSuccess.tsx` にて、GTMへ `form_success` イベントを送信するコードを追加
  - SPA構成でURLが変化しないため、Reactの `useEffect` を使って `window.dataLayer.push()` による明示的なイベント発火が必要なため対応
- TypeScriptで `window.dataLayer` が未定義扱いにならないよう、型定義を `declare global` にて補完