### PR TITLE
feat: Metaタグをを送信するトリガーを追加

### DIFF
--- a/src/components/form/FormSuccess.tsx
+++ b/src/components/form/FormSuccess.tsx
@@ -10,11 +10,14 @@ declare global {
 
 const FormSuccess = () => {
   useEffect(() => {
-    // GTM用イベント送信
-    if (window.dataLayer) {
-      window.dataLayer.push({
-        event: "form_success", // ← GTMのトリガー名と一致させる
-      });
+    if (!window.dataLayer) return;
+  
+    // 発火済みチェック
+    const alreadyPushed = window.dataLayer.some(
+      (e) => e.event === "form_success"
+    );
+    if (!alreadyPushed) {
+      window.dataLayer.push({ event: "form_success" });
     }
   }, []);
 

--- a/src/components/lp/main.tsx
+++ b/src/components/lp/main.tsx
@@ -342,7 +342,13 @@ export default function Main({
         </div>
       </section>
       <DiagnosisButton />
-      <FixedButton onClick={() => setStartDiagnosis(true)} showGlassIcon>
+      <FixedButton
+        onClick={() => {
+          window.dataLayer?.push({ event: "start_diagnosis_clicked" });
+          setStartDiagnosis(true);
+        }}
+        showGlassIcon
+      >
         診断スタート
       </FixedButton>
     </div>


### PR DESCRIPTION
### 関連issue番号
#1

### 修正内容
- Meta Pixel タグを、「診断スタートボタンクリック時」と最後の「診断ありがとうございました」ページが表示されるタイミングでのトリガー を`main.tsx`と`FormSuccess.tsx`に追加し、各タイミングでのMetaタグが送信されるようにコード追加。

※ブランチ名feat/1内でMeta修正を入れてなかったため臨時でfeat/1-add-metatagと今回のfeat/1-add-meta-tag-trigerブランチを切りマージ。